### PR TITLE
Separate inline assets into external CSS and JavaScript files

### DIFF
--- a/css/noscript.css
+++ b/css/noscript.css
@@ -1,0 +1,4 @@
+.reveal {
+  opacity: 1 !important;
+  transform: none !important;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,128 @@
+:root {
+  --bg: #000;
+  --card: #0a0a0a;
+  --border: #1f2937;
+  --text: #fff;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+}
+
+a {
+  color: #fff;
+}
+
+.glass {
+  background: rgba(255, 255, 255, 0.02);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+}
+
+.accent-ring {
+  box-shadow: 0 0 0 2px #fff inset;
+}
+
+.ph {
+  aspect-ratio: 4 / 3;
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Progressive reveal */
+.reveal {
+  opacity: 1;
+  transform: none;
+}
+
+.js .reveal {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.js .reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.js .reveal.visible {
+  animation: reveal 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+/* Pulse */
+@keyframes pulse-soft {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+
+  50% {
+    transform: scale(1.03);
+    opacity: 1;
+  }
+}
+
+.pulse-badge {
+  animation: pulse-soft 2s infinite ease-in-out;
+}
+
+/* Accessibility */
+.sr-skip:focus {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  background: #fff;
+  color: #000;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  z-index: 50;
+}
+
+:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+/* Motion reduce */
+@media (prefers-reduced-motion: reduce) {
+  .pulse-badge,
+  .js .reveal.visible {
+    animation: none !important;
+  }
+
+  * {
+    scroll-behavior: auto;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <!-- JS-first flag for progressive reveal -->
-  <script>document.documentElement.classList.add('js')</script>
+  <script src="js/init.js"></script>
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -34,41 +34,10 @@
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
-
-  <style>
-    :root { --bg:#000; --card:#0a0a0a; --border:#1f2937; --text:#fff; }
-    html { scroll-behavior: smooth; }
-    body { background: var(--bg); color: var(--text); font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
-    a { color:#fff; }
-    .glass { background: rgba(255,255,255,0.02); backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
-    .card { background: var(--card); border: 1px solid var(--border); }
-    .accent-ring { box-shadow: 0 0 0 2px #fff inset; }
-    .ph { aspect-ratio: 4 / 3; border: 1px dashed rgba(255,255,255,.4); background: rgba(255,255,255,.03); border-radius: .75rem; display:flex; align-items:center; justify-content:center; font-size:.875rem; color:rgba(255,255,255,.75); text-transform:uppercase; letter-spacing:.06em; }
-
-    /* Progressive reveal */
-    .reveal{opacity:1; transform:none}
-    .js .reveal{opacity:0; transform:translateY(20px)}
-    .js .reveal.visible{opacity:1; transform:translateY(0)}
-    @keyframes reveal { 0%{opacity:0;transform:translateY(20px)} 100%{opacity:1;transform:translateY(0)} }
-    .js .reveal.visible { animation: reveal .6s cubic-bezier(.25,.46,.45,.94) both }
-
-    /* Pulse */
-    @keyframes pulse-soft { 0%,100%{ transform: scale(1); opacity:.85 } 50%{ transform: scale(1.03); opacity:1 } }
-    .pulse-badge { animation: pulse-soft 2s infinite ease-in-out }
-
-    /* Accessibility */
-    .sr-skip:focus { position: fixed; top:.5rem; left:.5rem; background:#fff; color:#000; padding:.5rem .75rem; border-radius:.375rem; z-index:50 }
-    :focus-visible { outline:2px solid #fff; outline-offset:2px }
-
-    /* Motion reduce */
-    @media (prefers-reduced-motion: reduce){
-      .pulse-badge, .js .reveal.visible { animation:none !important }
-      * { scroll-behavior: auto }
-    }
-  </style>
+  <link rel="stylesheet" href="css/styles.css">
 
   <noscript>
-    <style>.reveal{opacity:1 !important; transform:none !important}</style>
+    <link rel="stylesheet" href="css/noscript.css">
   </noscript>
 
   <!-- Organization -->
@@ -354,7 +323,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <h2 class="text-2xl sm:text-3xl font-semibold">Contact</h2>
       <div class="mt-8 grid lg:grid-cols-2 gap-6">
-        <form class="card rounded-2xl p-6" novalidate onsubmit="event.preventDefault(); document.getElementById('formMsg')?.classList.remove('hidden'); this.reset();">
+        <form id="contactForm" class="card rounded-2xl p-6" novalidate>
           <label class="block text-sm">Name
             <input required autocomplete="name" type="text" class="mt-2 w-full rounded-lg bg-black border border-white/20 px-3 py-2" placeholder="Your name" />
           </label>
@@ -398,34 +367,6 @@
     </div>
   </footer>
 
-  <script>
-    // Mobile menu
-    const btn = document.getElementById('menuBtn');
-    const menu = document.getElementById('mobileMenu');
-    if (btn && menu) {
-      btn.addEventListener('click', () => {
-        const open = menu.classList.toggle('hidden');
-        btn.setAttribute('aria-expanded', String(!open));
-      });
-      menu.querySelectorAll('a').forEach(a => a.addEventListener('click', () => menu.classList.add('hidden')));
-    }
-
-    // Current year
-    const yEl = document.getElementById('y');
-    if (yEl) yEl.textContent = new Date().getFullYear();
-
-    // Reveal on scroll with graceful fallback
-    const io = 'IntersectionObserver' in window ? new IntersectionObserver((entries, obs) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('visible');
-          obs.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.1 }) : null;
-
-    if (io) document.querySelectorAll('.reveal').forEach(el => io.observe(el));
-    else document.querySelectorAll('.reveal').forEach(el => el.classList.add('visible'));
-  </script>
+  <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/init.js
+++ b/js/init.js
@@ -1,0 +1,1 @@
+document.documentElement.classList.add('js');

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('menuBtn');
+  const menu = document.getElementById('mobileMenu');
+
+  if (btn && menu) {
+    btn.addEventListener('click', () => {
+      const isHidden = menu.classList.toggle('hidden');
+      btn.setAttribute('aria-expanded', String(!isHidden));
+    });
+
+    menu.querySelectorAll('a').forEach((link) =>
+      link.addEventListener('click', () => menu.classList.add('hidden'))
+    );
+  }
+
+  const yEl = document.getElementById('y');
+  if (yEl) {
+    yEl.textContent = new Date().getFullYear();
+  }
+
+  const form = document.getElementById('contactForm');
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const status = document.getElementById('formMsg');
+      if (status) {
+        status.classList.remove('hidden');
+      }
+      form.reset();
+    });
+  }
+
+  const revealElements = document.querySelectorAll('.reveal');
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            obs.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    revealElements.forEach((element) => observer.observe(element));
+  } else {
+    revealElements.forEach((element) => element.classList.add('visible'));
+  }
+});


### PR DESCRIPTION
## Summary
- move the inline styling from `index.html` into a dedicated `css/styles.css` file with a `noscript` fallback stylesheet
- extract the progressive enhancement logic into `js/init.js` and `js/main.js`, including a DOM-based contact form handler
- update `index.html` to reference the new assets and remove inline event handlers

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca093f8758832fbed06f05b962c185